### PR TITLE
not including port in production

### DIFF
--- a/etc/nginx.conf.erb
+++ b/etc/nginx.conf.erb
@@ -134,4 +134,8 @@ http {
     <% end %>
 
     <%= include_passenger_internal_template('footer.erb', 4) %>
+
+    <% if ENV["PASSENGER_ENVIRONMENT"] == "production" %>
+        port_in_redirect off;
+    <% end %>
 }


### PR DESCRIPTION
```
$ curl -I http://localhost:8080/cli.html
HTTP/1.1 302 Moved Temporarily
Server: nginx
Date: Thu, 14 Sep 2017 21:16:11 GMT
Content-Type: text/html
Content-Length: 154
Location: http://localhost:8080/cli
Connection: keep-alive
```

```
$ curl -I https://manual.cs50.net/cli.html
HTTP/1.1 302 Moved Temporarily
Cache-control: no-cache="set-cookie"
Content-Length: 154
Content-Type: text/html
Date: Thu, 14 Sep 2017 21:17:44 GMT
Location: http://manual.cs50.net/cli
Server: nginx/1.10.3
Set-Cookie: AWSELB=CB83D98710E2E9D24E2197B807CC4CE925539FD97B1455FAD415000EB26807AF1CA029438AB8619B7C7F4C2A23D2B0AE4A077EB976EC08FB51207615317EDC56FA820B5B6E;PATH=/
Connection: keep-alive
```